### PR TITLE
Add doze mode awareness

### DIFF
--- a/jobqueue/AndroidManifest.xml
+++ b/jobqueue/AndroidManifest.xml
@@ -3,6 +3,5 @@
           package="com.path.android.jobqueue"
           android:versionCode="2"
           android:versionName="1.1.2">
-    <application android:label="">
-    </application>
+    <application />
 </manifest>

--- a/jobqueue/build.gradle
+++ b/jobqueue/build.gradle
@@ -1,8 +1,7 @@
-import com.android.builder.core.BuilderConstants
-
 import java.util.regex.Pattern
+
 task wrapper(type: Wrapper) {
-    gradleVersion = '1.10'
+    gradleVersion = '2.8'
 }
 
 apply plugin: 'maven'
@@ -48,7 +47,7 @@ println "version name:${manifestVersionName}"
 android.libraryVariants.all { variant ->
     def name = variant.buildType.name
     println "checking variant ${name}"
-    if (name.equals(BuilderConstants.DEBUG)) {
+    if (variant.buildType.isDebuggable()) {
         return; // Skip debug builds.
     }
     def suffix = name.capitalize()

--- a/jobqueue/build.gradle
+++ b/jobqueue/build.gradle
@@ -1,3 +1,5 @@
+import com.android.builder.core.BuilderConstants
+
 import java.util.regex.Pattern
 task wrapper(type: Wrapper) {
     gradleVersion = '1.10'
@@ -10,10 +12,6 @@ buildscript {
     repositories {
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
-    }
 }
 
 configurations {
@@ -22,11 +20,11 @@ configurations {
     }
 }
 
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -46,10 +44,11 @@ def manifestVersionName = matcher.group(1)
 println "version name:${manifestVersionName}"
 
 //create jar tasks
+
 android.libraryVariants.all { variant ->
     def name = variant.buildType.name
     println "checking variant ${name}"
-    if (name.equals(com.android.builder.BuilderConstants.DEBUG)) {
+    if (name.equals(BuilderConstants.DEBUG)) {
         return; // Skip debug builds.
     }
     def suffix = name.capitalize()
@@ -61,7 +60,7 @@ android.libraryVariants.all { variant ->
     }
     def javadocTask = project.tasks.create(name: "javadoc${suffix}", type: Javadoc) {
         source = variant.javaCompile.source
-        ext.androidJar = "${android.plugin.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
+        ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
         classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
     }
 
@@ -71,7 +70,7 @@ android.libraryVariants.all { variant ->
     }
 
     def sourcesJarTask = project.tasks.create(name: "sourceJar${suffix}", type: Jar) {
-        from android.sourceSets.main.allSource
+        from android.sourceSets.main.java
         classifier = 'sources'
     }
     artifacts.add('archives', jarTask);

--- a/jobqueue/src/com/path/android/jobqueue/network/NetworkUtilImpl.java
+++ b/jobqueue/src/com/path/android/jobqueue/network/NetworkUtilImpl.java
@@ -36,6 +36,9 @@ public class NetworkUtilImpl implements NetworkUtil, NetworkEventProvider {
 
     @Override
     public boolean isConnected(Context context) {
+        // During Doze mode, also called Idle, the network is unavailable but isConnectedOrConnecting()
+        // will return true. So we first check if we are in idle mode through the PowerManager before
+        // trusting the ConnectivityManager.
         if (VERSION.SDK_INT >= VERSION_CODES.M) {
             PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
             if (powerManager.isDeviceIdleMode()) {


### PR DESCRIPTION
Android M adds Doze mode and App Standby. This change aims to make the Job Manager work with Doze mode.

Doze mode disables access to network while active, but isConnectedOrConnecting() says there is network. This results in the Job Manager thinking there is network, scheduling jobs to run that require the network, those jobs failing and then being rescheduled (just to fail again).

Additionally when Doze exits a network broadcast (CONNECTIVITY_ACTION) is NOT sent. So until another job is entered into the queue or the device loses internet and gains it back, networking jobs will be idle even after Doze is finished. By listening to ACTION_DEVICE_IDLE_MODE_CHANGED the Job Manager can update the network queue accordingly.
